### PR TITLE
Untested Changes to Add Chrome Profile Targetting

### DIFF
--- a/app/extensionendpoint/extensionendpoint.go
+++ b/app/extensionendpoint/extensionendpoint.go
@@ -31,7 +31,7 @@ func AnswerToExtension() {
 			rsp.Text = "Unknown OS"
 		} else {
 			rsp.Text = "ok"
-			err = openChrome(msg.Url)
+			err = openChrome(msg.Profile, msg.Url)
 
 			if err != nil {
 				rsp.Success = false
@@ -47,7 +47,8 @@ func AnswerToExtension() {
 }
 
 type message struct {
-	Url string `json:"url"`
+    Profile string `json:"profile"`,
+    Url string `json:"url"`
 }
 
 type response struct {

--- a/app/extensionendpoint/openChrome_darwin.go
+++ b/app/extensionendpoint/openChrome_darwin.go
@@ -2,7 +2,7 @@ package extensionendpoint
 
 import "os/exec"
 
-func openChrome(url string) error {
-	cmd := exec.Command("open", "-a", "Google Chrome", url)
+func openChrome(profile string, url string) error {
+    cmd := exec.Command("open", "-n", "-a", "Google Chrome", url, "--profile-directory='".join(profile).join("'"))
 	return cmd.Run()
 }

--- a/app/extensionendpoint/openChrome_windows.go
+++ b/app/extensionendpoint/openChrome_windows.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func openChrome(url string) error {
+func openChrome(profile string, url string) error {
 	var path string
 
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe`, registry.READ)
@@ -15,7 +15,7 @@ func openChrome(url string) error {
 		defer k.Close()
 		path, _, err = k.GetStringValue("")
 		if err == nil {
-			cmd := exec.Command(path, url)
+            cmd := exec.Command(path, "--profile-directory='".join(profile).join("'"), url)
 			err = cmd.Run()
 		}
 	}

--- a/extension/options.html
+++ b/extension/options.html
@@ -8,15 +8,16 @@
 
 <body style="min-width: 200px;">
     <h1>OnChrome</h1>
-    <p>The following urls will be opened in Chrome automatically.</p>
     <form id="the-form"
         class="container"
         method="POST"
         action="">
+    <p>The following urls will be opened in Chrome automatically.</p>
         <label>
             Url <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a> (one per line)<br />
             <textarea style="width: 100%" rows="10" id="urls"></textarea>
-        </label><p />
+        </label>
+    <p>Chrome will be called using the following profile (i.e. <pre>--profile-directory="&ltprofile&gt"</pre>)</p>
         <label>
             Chrome profile: "Default" (to force <i>default</i> profile) or "Profile <i>n</i>"); leave blank for <i>last-used</i> profile<br />
             <input type="text" size="15" id="profile"></input>

--- a/extension/options.html
+++ b/extension/options.html
@@ -16,6 +16,10 @@
         <label>
             Url <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a> (one per line)<br />
             <textarea style="width: 100%" rows="10" id="urls"></textarea>
+        </label><p />
+        <label>
+            Chrome profile: "Default" (to force <i>default</i> profile) or "Profile <i>n</i>"); leave blank for <i>last-used</i> profile<br />
+            <input type="text" size="15" id="profile"></input>
         </label>
         <button type="button" id="save" style="width: 100%">Save</button>
     </form>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,6 +1,7 @@
 const save = document.getElementById("save");
 save.addEventListener("click", () => {
     let urls = document.getElementById("urls").value;
+    let profile = document.getElementById("profile").value;
     let valueToSave = [];
 
     if (urls) {
@@ -10,19 +11,27 @@ save.addEventListener("click", () => {
         }
     }
     browser.storage.sync.set({
-        urls: JSON.stringify(valueToSave)
+        urls: JSON.stringify(valueToSave),
+        profile: JSON.stringify(profile)
     }, () => {
         chrome.runtime.sendMessage({ type: "urlsUpdated" });
         window.close();
     });
 })
 
-chrome.storage.sync.get(["urls"], res => {
+chrome.storage.sync.get(["urls","profile"], res => {
     var urls = res.urls;
     if (urls) {
         urls = JSON.parse(urls);
         if (urls.length) {
             document.getElementById("urls").value = urls.join("\n");
+        }
+    }
+    var profile = res.profile;
+    if (profile) {
+        profile = JSON.parse(profile);
+        if (profile.length) {
+            document.getElementById("profile").value = profile;
         }
     }
 })


### PR DESCRIPTION
My _totally_ untested, "quick and dirty" changes to allow for Chrome profile targeting.

Apologies in advance: Unable to test due to lack of Go compiler and knowledge of Go (and lack of Mac OSX also)...

Note that according to https://superuser.com/questions/759535/open-google-chrome-specific-profile-from-command-line-macm, OSX may require "-n" parameter for Chrome to open with specific profile (if another instance of Chrome is already running).