### PR TITLE
Allow exclusion matches

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -7,30 +7,42 @@ function onError(error) {
 }
 
 var currentProfile;
-const blockUrl = function (requestDetails) {
-    return new Promise(function(resolve, reject) {
-        browser.runtime.sendNativeMessage(
-            "me.onchro",
-            { url: requestDetails.url, profile: currentProfile }).then(() => browser.tabs.remove(requestDetails.tabId), onError);
-        resolve({cancel: true});
-      });
+const blockUrl = function (exclusions) {
+    return function(requestDetails){
+        return new Promise(function(resolve, reject) {
+            var resolved = false;
+            for(exclusion of exclusions){
+                if(requestDetails.url.match(new RegExp(exclusion))) {
+                    resolve({cancel:false});
+                    resolved = true;
+                }
+            }
+            if (!resolved){
+                browser.runtime.sendNativeMessage(
+                    "me.onchro",
+                    { url: requestDetails.url, profile: currentProfile }).then(() => browser.tabs.remove(requestDetails.tabId), onError);
+                resolve({cancel: true});
+            }
+        });
+    }
 }
 
-function registerUrls(urls, profile) {
+function registerUrls(urls, exclusions, profile) {
     currentProfile = profile;
     if (urls) {
         urls = JSON.parse(urls);
+        exclusions = JSON.parse(exclusions);
         if (urls && urls.length) {
-            browser.webRequest.onBeforeRequest.addListener(blockUrl, { urls: urls, types: ["main_frame"] }, ["blocking"])
+            browser.webRequest.onBeforeRequest.addListener(blockUrl(exclusions), { urls: urls, types: ["main_frame"] }, ["blocking"])
         }
     }
 }
 
-chrome.storage.sync.get(["urls"], res => registerUrls(res.urls))
+chrome.storage.sync.get(["urls", "exclusions"], res => registerUrls(res.urls, res.exclusions))
 
 browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === "urlsUpdated") {
         browser.webRequest.onBeforeRequest.removeListener(blockUrl)
-        chrome.storage.sync.get(["urls", "profile"], res => registerUrls(res.urls, res.profile))
+        chrome.storage.sync.get(["urls", "profile", exclusions], res => registerUrls(res.urls, res.exclusions, res.profile))
     }
 });

--- a/extension/background.js
+++ b/extension/background.js
@@ -6,43 +6,36 @@ function onError(error) {
     });
 }
 
-var currentProfile;
-const blockUrl = function (exclusions) {
-    return function(requestDetails){
-        return new Promise(function(resolve, reject) {
-            var resolved = false;
-            for(exclusion of exclusions){
-                if(requestDetails.url.match(new RegExp(exclusion))) {
-                    resolve({cancel:false});
-                    resolved = true;
-                }
-            }
-            if (!resolved){
-                browser.runtime.sendNativeMessage(
-                    "me.onchro",
-                    { url: requestDetails.url, profile: currentProfile }).then(() => browser.tabs.remove(requestDetails.tabId), onError);
-                resolve({cancel: true});
-            }
-        });
-    }
+var currentProfile, currentExclusions;
+const blockUrl = function (requestDetails) {
+    return new Promise(function (resolve, reject) {
+        if (currentExclusions.find(r => requestDetails.url.match(r))) {
+            resolve({ cancel: false });
+            return
+        }
+        browser.runtime.sendNativeMessage(
+            "me.onchro",
+            { url: requestDetails.url, profile: currentProfile }).then(() => browser.tabs.remove(requestDetails.tabId), onError);
+        resolve({ cancel: true });
+    });
 }
 
 function registerUrls(urls, exclusions, profile) {
     currentProfile = profile;
     if (urls) {
         urls = JSON.parse(urls);
-        exclusions = JSON.parse(exclusions);
+        currentExclusions = exclusions ? JSON.parse(exclusions).map(s => new RegExp(s)) : [];
         if (urls && urls.length) {
-            browser.webRequest.onBeforeRequest.addListener(blockUrl(exclusions), { urls: urls, types: ["main_frame"] }, ["blocking"])
+            browser.webRequest.onBeforeRequest.addListener(blockUrl, { urls: urls, types: ["main_frame"] }, ["blocking"])
         }
     }
 }
 
-chrome.storage.sync.get(["urls", "exclusions"], res => registerUrls(res.urls, res.exclusions))
+chrome.storage.sync.get(["urls", "profile", "exclusions"], res => registerUrls(res.urls, res.exclusions, res.profile))
 
 browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === "urlsUpdated") {
         browser.webRequest.onBeforeRequest.removeListener(blockUrl)
-        chrome.storage.sync.get(["urls", "profile", exclusions], res => registerUrls(res.urls, res.exclusions, res.profile))
+        chrome.storage.sync.get(["urls", "profile", "exclusions"], res => registerUrls(res.urls, res.exclusions, res.profile))
     }
 });

--- a/extension/options.html
+++ b/extension/options.html
@@ -18,6 +18,10 @@
             <textarea style="width: 100%" rows="10" id="urls"></textarea>
         </label>
         <label>
+            Exclusions: Regular expression matches (one per line)<br />
+            <textarea style="width: 100%" rows="10" id="exclusions"></textarea>
+        </label>
+        <label>
             Chrome profile (leave blank for <i>last-used</i> profile):
             <input type="text" size="15" id="profile"></input>
         </label>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,30 +1,48 @@
 const save = document.getElementById("save");
 save.addEventListener("click", () => {
     let urls = document.getElementById("urls").value;
+    let exclusions = document.getElementById("exclusions").value;
     let profile = document.getElementById("profile").value;
-    let valueToSave = [];
+    let urlMatchPatternsToSave = [];
 
     if (urls) {
         urls = urls.split(/\r?\n/);
         if (urls.length) {
-            valueToSave = urls;
+            urlMatchPatternsToSave = urls;
         }
     }
+
+    if (exclusions) {
+        exclusions = exclusions.split(/\r?\n/);
+        if (exclusions.length) {
+            exclusionsToSave = exclusions;
+        }
+    } else {
+        exclusionsToSave = [];
+    }
     browser.storage.sync.set({
-        urls: JSON.stringify(valueToSave),
-        profile: profile
+        urls: JSON.stringify(urlMatchPatternsToSave),
+        profile: profile,
+        exclusions: JSON.stringify(exclusionsToSave)
     }, () => {
         chrome.runtime.sendMessage({ type: "urlsUpdated" });
         window.close();
     });
 })
 
-chrome.storage.sync.get(["urls","profile"], res => {
+chrome.storage.sync.get(["urls","profile","exclusions"], res => {
     var urls = res.urls;
     if (urls) {
         urls = JSON.parse(urls);
         if (urls.length) {
             document.getElementById("urls").value = urls.join("\n");
+        }
+    }
+    var exclusions = res.exclusions;
+    if (exclusions) {
+        exclusions = JSON.parse(exclusions);
+        if (exclusions.length) {
+            document.getElementById("exclusions").value = exclusions.join("\n");
         }
     }
     if (res.profile) {


### PR DESCRIPTION
We have a few subdomains that I'd like to keep accessing through firefox; all the other ones should be opened in Chrome.

This PR adds the ability to add matches to an 'exclusions' list that is, at its easiest, just a list of words that 'blacklist' a URL from being opened in Chrome, or a more advanced regular expression for more finegrained control.

![image](https://user-images.githubusercontent.com/2945304/82960334-3615fa00-9f88-11ea-8e3b-568753c308fc.png)

Thank you for this plugin, it's making my (and my colleagues') life much easier!